### PR TITLE
Eliminate warning raised by Elixir v1.11 compiler

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,8 @@ defmodule Asn1ex.Mixfile do
   def project do
     [app: :asn1ex,
      version: "0.0.1",
-     deps: deps()]
+     deps: deps(),
+     xref: [exclude: :asn1ct]]
   end
 
   def application do


### PR DESCRIPTION
With the upcoming v1.11 we get the following warning. I think 3rd option is the best choice in case of `:acn1ct`.

```
% mix compile  
Compiling 1 file (.ex)
warning: :asn1ct.compile/2 defined in application :asn1 is used by the current application but the current application does not directly depend on :asn1. To fix this, you must do one of:

  1. If :asn1 is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :asn1 is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :asn1, you may optionally skip this warning by adding [xref: [exclude: :asn1ct] to your "def project" in mix.exs

  lib/mix/tasks/compile.asn1.ex:55: Mix.Tasks.Compile.Asn1.run/1

Generated asn1ex app
```